### PR TITLE
Fix requirement typo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,6 @@ pycountry==24.6.1
 pycparser==2.22
 pyjwt==2.10.1
 pyodbc==5.2.0
-pyodc==1.4.1
 pyparsing==3.2.1
 python-dateutil==2.9.0.post0
 python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- remove stray `pyodc` package from requirements

## Testing
- `pytest test_sql_connection.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6841572f0f708327b71352090b9c5502